### PR TITLE
Fixed recreating credentials after timeout

### DIFF
--- a/gsheet.py
+++ b/gsheet.py
@@ -6,15 +6,27 @@ from itertools import zip_longest
 class Sheet:
 
 	def __init__(self):
+		self.authorize()
+
+	def authorize(self):
+		print("Generating Credentials for connection")
 		scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
 		creds = ServiceAccountCredentials.from_json_keyfile_name('StratRouletteKey.json', scope)
 		self.client = gspread.authorize(creds)
 
 		self.sheet = self.client.open('DP strat roulette').sheet1
 
+	def get_cols(self):
+		return [self.sheet.col_values(i) for i in range(1,5)]
+
 	def get_table(self):
-		cols = [self.sheet.col_values(i) for i in range(1,5)]
-		table = [row for row in zip_longest(*cols) if len(row) == 4 and row[0]] 
+		try:
+			cols = self.get_cols()
+		except gspread.exceptions.APIError:
+			self.authorize()
+			cols = self.get_cols()
+
+		table = [row for row in zip_longest(*cols) if len(row) == 4 and row[0]]
 
 		return table[1:]
 


### PR DESCRIPTION
The oauth2client credentials have abuilt in timeout of 1 hour. This meant that if the bot ran for longer than that the credentials would expire and it couldn't update any more. This PR fixes it so if the credentials error it will recreate them and try again. Tested by waiting an hour an half between calls, and it successfully handled the regeneration of credentials